### PR TITLE
Add gzip compression to nginx config

### DIFF
--- a/dynamic-sites.conf
+++ b/dynamic-sites.conf
@@ -5,6 +5,18 @@ server {
     root /sites/default/;
     error_log  /var/log/nginx/error.log;
     access_log  /var/log/nginx/access.log;
+    
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types application/atom+xml application/javascript application/json application/rss+xml
+      application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml
+      application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component;
+
 
     location / {
     	if (-d /sites/$domain) {


### PR DESCRIPTION
Gzip compression for static sites is one of the best practices. I don't see any disadvantages of adding this into the config